### PR TITLE
fix: revert payload plugin (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ export const MyCollection: CollectionConfig = {
 
 ### Initialize Assist for Payload
 
-The main `payloadAssist` function initializes the library and validates your payload config against defined rules. You can customize the `ruleSet` and `transformAndValidate` function through options.
+The main `payloadAssist` function initializes the library, validates your payload config against defined rules, and returns the built config. You can customize the `ruleSet` and `transformAndValidate` function through options.
+payloadAssist is implemenented as a wrapper function and not as a payload plugin, to ensure it validates the raw config that is set by the user, instead of the config that was previously processed by other plugins and enriched by payload.
 
 - **ruleSet**: An object map of named rules; merge defaults with your own, if required. Deactivate a default rule by setting the rule to `false`.
 - **rules**: `(config: payloadConfig) => boolean | void`; throw to fail with an actionable message and return true if the rule is satisfied.
@@ -92,19 +93,15 @@ The main `payloadAssist` function initializes the library and validates your pay
 import { buildConfig } from "payload";
 import payloadAssist, { defaultConfig } from "@byte5digital/payload-assist";
 
-export default buildConfig({
+export default payloadAssist({
   // your Payload config
-  plugins: [
-    payloadAssist(
-      {
-        ruleSet: {
-          ...defaultConfig.ruleSet,
-          // add/override rules here
-          secretIsSet: (config) => config.secret?.length > 0 ? true : throw 'A secret needs to be set',
-        },
-      }
-    ),
-  ]
+}, {
+  ruleSet: {
+    ...defaultConfig.ruleSet,
+
+    // add/override rules here
+    secretIsSet: (config) => config.secret?.length > 0 ? true : throw 'A secret needs to be set',
+  },
 });
 ```
 
@@ -154,7 +151,10 @@ Use `withResponse` to guarantee your endpoints return DTOs (and nothing else). I
 
 ```ts
 import payload from "payload";
-import { withResponse, transformAndValidate } from "@byte5digital/payload-assist";
+import {
+  withResponse,
+  transformAndValidate,
+} from "@byte5digital/payload-assist";
 import { MyDataDto } from "path/to/dtos";
 
 export const MyCollection: CollectionConfig = {

--- a/src/utils/payload-assist.ts
+++ b/src/utils/payload-assist.ts
@@ -1,6 +1,6 @@
 import { PayloadAssistConfig, PayloadAssistOptions } from "../types/config";
 import payloadAssistDefaultConfig from "../default.config";
-import { Config as PayloadConfig, Plugin } from "payload";
+import { buildConfig, Config as PayloadConfig } from "payload";
 
 export { payloadAssistDefaultConfig as defaultConfig };
 
@@ -12,32 +12,33 @@ export let payloadAssistConfig: PayloadAssistConfig | undefined = undefined;
  * @param options - The options to cusotmize payloadAssist.
  * @returns Built and sanitized Payload Config
  */
-export const payloadAssist =
-  (options?: PayloadAssistOptions): Plugin =>
-  (payloadConfig: PayloadConfig) => {
-    if (payloadAssistConfig) throw `PayloadAssist is already initialized`;
+export const payloadAssist = (
+  payloadConfig: PayloadConfig,
+  options?: PayloadAssistOptions
+) => {
+  if (payloadAssistConfig) throw `PayloadAssist is already initialized`;
 
-    payloadAssistConfig = {
-      ...payloadAssistDefaultConfig,
-      ...(options ?? {}),
-    };
-
-    Object.entries(payloadAssistConfig.ruleSet).reduce(
-      (payloadConfig, [ruleName, rule]) => {
-        try {
-          if (rule === false) return payloadConfig; // rule is deactivated, so we skip it
-          if (!rule(payloadConfig))
-            throw `The payload config does not satisfy "${ruleName}".`;
-        } catch (error) {
-          throw `[PayloadAssist Error]: ${ruleName}: ${error}`;
-        }
-        return payloadConfig;
-      },
-      payloadConfig
-    );
-
-    return payloadConfig;
+  payloadAssistConfig = {
+    ...payloadAssistDefaultConfig,
+    ...(options ?? {}),
   };
+
+  Object.entries(payloadAssistConfig.ruleSet).reduce(
+    (payloadConfig, [ruleName, rule]) => {
+      try {
+        if (rule === false) return payloadConfig; // rule is deactivated, so we skip it
+        if (!rule(payloadConfig))
+          throw `The payload config does not satisfy "${ruleName}".`;
+      } catch (error) {
+        throw `[PayloadAssist Error]: ${ruleName}: ${error}`;
+      }
+      return payloadConfig;
+    },
+    payloadConfig
+  );
+
+  return buildConfig(payloadConfig);
+};
 
 /**
  * Resets internal module state for tests or reinitialization.


### PR DESCRIPTION
* Revert "fix: Turn into payload plugin"

This reverts commit 25f2aad4760445de50ff3be5ea6aa93cb8bfdacc.

* Revert "feat: update README"

This reverts commit 7d90b2b6028200ef77e7240f3d406803d689f703.

* chore: add hint to readme that states why payload assist is not setup as a plugin

---------